### PR TITLE
feat: add callback functions and toggleable boolean flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,36 @@ equivalent.
     $ example arg1 -t3.14 arg2
     $ example arg1 arg2 -t 3.14
 
+### Callback functions
+
+Is is possible to register command line arguments with callback functions
+through the `<Type>Func` and `<Type>FuncP` functions. These callback functions
+will be called after an argument's value is changed, with the new value as their
+sole parameter. They may return an error which will interrupt argument parsing.
+
+This allows arguments-related state to be used during parsing and not only once
+it is done.
+
+    $ example -p --thingy -p
+    The thingy is disabled.
+    The thingy is enabled.
+    $ example -p --quiet -p
+    The thingy is disabled.
+    ERROR: Cannot print the thingy's state in quiet mode
+
+### Toggleable booleans
+
+Unlike `flag`, this library does not support setting values for boolean flags
+directly. It is however possible to have two options that "negate" each other.
+
+	optThingy := golf.Bool("thingy=no", true, "Disable the thingy")
+	golf.BoolVar(optThingy, "thingy", false, "Enable the thingy")
+
+Because boolean flags will set the variable's value to the negation of their
+default value, the above two lines will allow `--thingy` and `--thingy=no` to
+be used to toggle the feature. The second line will set the variable's actual
+default.
+
 ## Help Example
 
 Invoking `golf.Usage()` will display the program name, followed by a

--- a/example/main.go
+++ b/example/main.go
@@ -22,6 +22,32 @@ func main() {
 	_ = golf.String("t", "host3,host4", "Another string")
 	_ = golf.String("flubbers", "host5", "Yet another string")
 
+	// Callbacks and bool default usage. Try it with
+	// "-p --thingy -p --thingy=no -p --quiet -p"
+	optThingy := golf.Bool("thingy=no", true, "Disable the thingy")
+	golf.BoolVar(optThingy, "thingy", false, "Enable the thingy")
+	_ = golf.BoolFuncP('p', "print-thingy", false, "Print the thingy's state", func(bool) error {
+		if *optQuiet {
+			return fmt.Errorf("Cannot print the thingy's state in quiet mode")
+		}
+		if *optThingy {
+			fmt.Fprintln(os.Stderr, "The thingy is enabled.")
+		} else {
+			fmt.Fprintln(os.Stderr, "The thingy is disabled.")
+		}
+		return nil
+	})
+
+	// Callbacks used for list construction
+	list := []string{}
+	_ = golf.StringFunc("a", "", "append to a list", func(v string) error {
+		if v == "" {
+			return fmt.Errorf("Cannot append empty string")
+		}
+		list = append(list, v)
+		return nil
+	})
+
 	golf.Parse()
 
 	if *optHelp || *optVersion {
@@ -41,4 +67,5 @@ func main() {
 	fmt.Fprintf(os.Stderr, "# limit: %v\n", *optLimit)
 	fmt.Fprintf(os.Stderr, "# quiet: %t\n", *optQuiet)
 	fmt.Fprintf(os.Stderr, "# verbose: %t\n", *optVerbose)
+	fmt.Fprintf(os.Stderr, "# list: %v\n", list)
 }

--- a/parse.go
+++ b/parse.go
@@ -131,7 +131,11 @@ func slurpText(text string, nextSlurp slurpType, f option) error {
 		err = fmt.Errorf("unexpected slurp state: %v", nextSlurp)
 	}
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	return f.Callback()
 }
 
 func parseArgs(args []string) error {
@@ -190,7 +194,9 @@ func parseArgs(args []string) error {
 					}
 					switch flagType = f.NextSlurp(); flagType {
 					case nothingToSlurp:
-						*f.(*optionBool).pv = true
+						if err := f.(*optionBool).toggleOption(); err != nil {
+							return err
+						}
 						runeParserState = wantShortFlagsOnly
 					default:
 						runeParserState = wantText
@@ -203,7 +209,9 @@ func parseArgs(args []string) error {
 				}
 				switch flagType = f.NextSlurp(); flagType {
 				case nothingToSlurp:
-					*f.(*optionBool).pv = true
+					if err := f.(*optionBool).toggleOption(); err != nil {
+						return err
+					}
 				default:
 					runeParserState = wantText
 				}
@@ -245,7 +253,9 @@ func parseArgs(args []string) error {
 				return fmt.Errorf("unknown flag: %q", flagName)
 			}
 			if flagType = f.NextSlurp(); flagType == nothingToSlurp {
-				*f.(*optionBool).pv = true
+				if err := f.(*optionBool).toggleOption(); err != nil {
+					return err
+				}
 			}
 			argsProcessed++
 		default:

--- a/parseBool_test.go
+++ b/parseBool_test.go
@@ -1,6 +1,7 @@
 package golf
 
 import (
+	"fmt"
 	"testing"
 	"unicode/utf8"
 )
@@ -290,4 +291,124 @@ func TestParseBoolPLongOption(t *testing.T) {
 			t.Errorf("GOT: %v; WANT: %v", got, want)
 		}
 	})
+}
+
+func TestParseBoolDefault(t *testing.T) {
+	t.Run("default to true", func(t *testing.T) {
+		resetParser()
+		a := BoolP('v', "verbose", true, "print verbose info")
+
+		if got, want := *a, true; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := parseArgs([]string{"-v"}), error(nil); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := *a, false; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+	})
+	t.Run("default to false", func(t *testing.T) {
+		resetParser()
+		a := BoolP('v', "verbose", false, "print verbose info")
+
+		if got, want := *a, false; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := parseArgs([]string{"-v"}), error(nil); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := *a, true; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+	})
+}
+
+func TestParseBoolFunc(t *testing.T) {
+	t.Run("callback called", func(t *testing.T) {
+		resetParser()
+		var cbArg *bool
+		opt := BoolFunc("o", false, "some option", func(v bool) error {
+			cbArg = &v
+			return nil
+		})
+
+		if got, want := *opt, false; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := parseArgs([]string{"-o"}), error(nil); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := *opt, true; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := (cbArg == nil), false; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := *cbArg, true; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+	})
+	t.Run("callback error", func(t *testing.T) {
+		resetParser()
+		cbErr := fmt.Errorf("failure is the only option")
+		opt := BoolFunc("o", false, "some option", func(v bool) error {
+			return cbErr
+		})
+
+		if got, want := *opt, false; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := parseArgs([]string{"-o"}), cbErr; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+	})
+}
+
+func TestParseBoolFuncP(t *testing.T) {
+	type Test struct {
+		title  string
+		parsed string
+	}
+	tests := []Test{{title: "short", parsed: "-o"}, {title: "long", parsed: "--option"}}
+	for _, test := range tests {
+		t.Run("callback called with "+test.title+" option", func(t *testing.T) {
+			resetParser()
+			var cbArg *bool
+			opt := BoolFuncP('o', "option", false, "some option", func(v bool) error {
+				cbArg = &v
+				return nil
+			})
+
+			if got, want := *opt, false; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := parseArgs([]string{test.parsed}), error(nil); got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := *opt, true; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := (cbArg == nil), false; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := *cbArg, true; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+		})
+		t.Run("callback error with "+test.title+" option", func(t *testing.T) {
+			resetParser()
+			cbErr := fmt.Errorf("failure is the only option")
+			opt := BoolFuncP('o', "option", false, "some option", func(v bool) error {
+				return cbErr
+			})
+
+			if got, want := *opt, false; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := parseArgs([]string{test.parsed}), cbErr; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+		})
+	}
 }

--- a/parseInt_test.go
+++ b/parseInt_test.go
@@ -1,6 +1,7 @@
 package golf
 
 import (
+	"fmt"
 	"testing"
 	"unicode/utf8"
 )
@@ -366,4 +367,93 @@ func TestParseIntPLongOption(t *testing.T) {
 			t.Errorf("GOT: %v; WANT: %v", got, want)
 		}
 	})
+}
+
+func TestParseIntFunc(t *testing.T) {
+	t.Run("callback called", func(t *testing.T) {
+		resetParser()
+		var cbArg *int
+		opt := IntFunc("o", 0, "some option", func(v int) error {
+			cbArg = &v
+			return nil
+		})
+
+		if got, want := *opt, int(0); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := parseArgs([]string{"-o", "12345"}), error(nil); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := *opt, 12345; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := (cbArg == nil), false; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := *cbArg, 12345; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+	})
+	t.Run("callback error", func(t *testing.T) {
+		resetParser()
+		cbErr := fmt.Errorf("failure is the only option")
+		opt := IntFunc("o", 0, "some option", func(v int) error {
+			return cbErr
+		})
+
+		if got, want := *opt, int(0); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := parseArgs([]string{"-o", "12345"}), cbErr; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+	})
+}
+
+func TestParseIntFuncP(t *testing.T) {
+	type Test struct {
+		title  string
+		parsed string
+	}
+	tests := []Test{{title: "short", parsed: "-o"}, {title: "long", parsed: "--option"}}
+	for _, test := range tests {
+		t.Run("callback called with "+test.title+" option", func(t *testing.T) {
+			resetParser()
+			var cbArg *int
+			opt := IntFuncP('o', "option", 0, "some option", func(v int) error {
+				cbArg = &v
+				return nil
+			})
+
+			if got, want := *opt, int(0); got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := parseArgs([]string{test.parsed, "12345"}), error(nil); got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := *opt, 12345; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := (cbArg == nil), false; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := *cbArg, 12345; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+		})
+		t.Run("callback error with "+test.title+" option", func(t *testing.T) {
+			resetParser()
+			cbErr := fmt.Errorf("failure is the only option")
+			opt := IntFuncP('o', "option", 0, "some option", func(v int) error {
+				return cbErr
+			})
+
+			if got, want := *opt, int(0); got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := parseArgs([]string{test.parsed, "12345"}), cbErr; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+		})
+	}
 }

--- a/parseUint64_test.go
+++ b/parseUint64_test.go
@@ -1,6 +1,7 @@
 package golf
 
 import (
+	"fmt"
 	"testing"
 	"unicode/utf8"
 )
@@ -366,4 +367,93 @@ func TestParseUint64PLongOption(t *testing.T) {
 			t.Errorf("GOT: %v; WANT: %v", got, want)
 		}
 	})
+}
+
+func TestParseUint64Func(t *testing.T) {
+	t.Run("callback called", func(t *testing.T) {
+		resetParser()
+		var cbArg *uint64
+		opt := Uint64Func("o", 0, "some option", func(v uint64) error {
+			cbArg = &v
+			return nil
+		})
+
+		if got, want := *opt, uint64(0); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := parseArgs([]string{"-o", "12345"}), error(nil); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := *opt, uint64(12345); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := (cbArg == nil), false; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := *cbArg, uint64(12345); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+	})
+	t.Run("callback error", func(t *testing.T) {
+		resetParser()
+		cbErr := fmt.Errorf("failure is the only option")
+		opt := Uint64Func("o", 0, "some option", func(v uint64) error {
+			return cbErr
+		})
+
+		if got, want := *opt, uint64(0); got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+		if got, want := parseArgs([]string{"-o", "12345"}), cbErr; got != want {
+			t.Errorf("GOT: %v; WANT: %v", got, want)
+		}
+	})
+}
+
+func TestParseUint64FuncP(t *testing.T) {
+	type Test struct {
+		title  string
+		parsed string
+	}
+	tests := []Test{{title: "short", parsed: "-o"}, {title: "long", parsed: "--option"}}
+	for _, test := range tests {
+		t.Run("callback called with "+test.title+" option", func(t *testing.T) {
+			resetParser()
+			var cbArg *uint64
+			opt := Uint64FuncP('o', "option", 0, "some option", func(v uint64) error {
+				cbArg = &v
+				return nil
+			})
+
+			if got, want := *opt, uint64(0); got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := parseArgs([]string{test.parsed, "12345"}), error(nil); got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := *opt, uint64(12345); got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := (cbArg == nil), false; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := *cbArg, uint64(12345); got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+		})
+		t.Run("callback error with "+test.title+" option", func(t *testing.T) {
+			resetParser()
+			cbErr := fmt.Errorf("failure is the only option")
+			opt := Uint64FuncP('o', "option", 0, "some option", func(v uint64) error {
+				return cbErr
+			})
+
+			if got, want := *opt, uint64(0); got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+			if got, want := parseArgs([]string{test.parsed, "12345"}), cbErr; got != want {
+				t.Errorf("GOT: %v; WANT: %v", got, want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This commit adds two features to the library :

* Support for callback functions that will be called when a flag's value is updated. These functions will be called with the flag's new value as their parameter, and will be able to return an error if necessary. Use-cases for this feature include on-the-fly validation and the construction of lists from complex command lines. This is an extension on the standard library's `BoolFunc` / `Func` functions.

* Toggleable boolean flags, which compensates for this library's inability to read values for boolean flags from the command line.

Both options have been documented in the README, tests have been added, and the example program has been updated to showcase both functionalities.